### PR TITLE
Fix firebase spotify auth error

### DIFF
--- a/spotify-clone-frontend/src/components/AuthGuard.jsx
+++ b/spotify-clone-frontend/src/components/AuthGuard.jsx
@@ -9,7 +9,6 @@ const AuthGuard = ({ children }) => {
   const { spotifyToken } = useSpotify();
   const location = useLocation();
 
-  // Show loading spinner while checking auth state
   if (authLoading) {
     return (
       <div className="h-screen bg-black flex items-center justify-center">
@@ -18,12 +17,12 @@ const AuthGuard = ({ children }) => {
     );
   }
 
-  // Redirect to login if not authenticated
-  if (!user) {
+  // Allow access if either Firebase user is authenticated OR Spotify token exists
+  if (!user && !spotifyToken) {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
-  // If user is authenticated but no Spotify token, redirect to Spotify auth
+  // If Firebase user exists but no Spotify token, show connect prompt
   if (user && !spotifyToken) {
     return (
       <div className="h-screen bg-black flex flex-col items-center justify-center text-white">
@@ -33,7 +32,7 @@ const AuthGuard = ({ children }) => {
             To use this app, you need to connect your Spotify account.
           </p>
           <button
-            onClick={() => window.location.href = 'http://127.0.0.1:5000/auth/login'}
+            onClick={() => (window.location.href = 'http://127.0.0.1:5000/auth/login')}
             className="bg-[#1db954] text-black px-8 py-3 rounded-full font-semibold hover:bg-[#1ed760] transition-colors"
           >
             Connect Spotify
@@ -43,7 +42,6 @@ const AuthGuard = ({ children }) => {
     );
   }
 
-  // User is fully authenticated, render children
   return children;
 };
 

--- a/spotify-clone-frontend/src/components/Dashboard.jsx
+++ b/spotify-clone-frontend/src/components/Dashboard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Sidebar from './Sidebar';
-import TopBar from './Topbar'; // Fixed: Changed from './Topbar' to './TopBar'
+import TopBar from './TopBar';
 import Home from './Home';
 import Search from './Search';
 import Library from './Library';


### PR DESCRIPTION
Enable Spotify-only authentication and fix a component import casing.

The "Firebase: invalid auth/credentials" error arose when users attempted to log in with Spotify credentials via the Firebase email/password form, which is intended for Firebase accounts. This PR updates the authentication guard to allow users to proceed with only a Spotify token, making Firebase login optional and resolving the credential mismatch. Additionally, it corrects a component import casing issue that caused build failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-b00f682f-a8e3-4a51-870b-151eec4ce3ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b00f682f-a8e3-4a51-870b-151eec4ce3ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

